### PR TITLE
If output dir specified, output all table files there

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ or pass a directory as variable to convert all pdf files within the directory:
 
 `python pdf-tables-to-markdown.py '<FILEPATH>/<DIRECTORY>'`
 
+or pass two directories to convert all pdf files from the first directory to the second:
+
+`python pdf-tables-to-markdown.py '<FILEPATH>/<DIRECTORY>' '<FILEPATH>/<DIRECTORY>'`
+
 ---
 
-Output file will be saved to `<FILEPATH>/<FILENAME>_<TABLENUMBER>.md`. 
+Output file will be saved to `<FILEPATH>/<FILENAME>/tables/table_<TABLENUMBER>.md`,
+or `<SECOND_DIR>/<FILENAME>_table_<TABLENUMBER>.md`. 
 Each table found in the pdf will be saved to a separate file.

--- a/pdf-tables-to-markdown.py
+++ b/pdf-tables-to-markdown.py
@@ -41,7 +41,13 @@ def convert_tables_to_md(pdf_file_name: Text):
             os.makedirs(os.path.join(md_file_name, 'tables'))
 
         # Save as markdown
-        with open(os.path.join(md_file_name, 'tables', 'table_' + str(i) + '.md'), 'w') as md_file:
+        output_dir = sys.argv[2] if len(sys.argv) == 3 else None
+        output_file_suffix = 'table_' + str(i) + '.md'
+        output_file_name = (
+            os.path.join(output_dir, os.path.split(md_file_name)[1] + '_' + output_file_suffix) if output_dir is not None
+            else os.path.join(md_file_name, 'tables', output_file_suffix)
+        )
+        with open(output_file_name, 'w') as md_file:
             md_file.write(md)
 
 


### PR DESCRIPTION
If an output directory is specified as a second argument, write all
table .md files there in the form `<pdf_name>_table_<number>.md`